### PR TITLE
Update URI for Redpanda console image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - 29092:29092
 
   console:
-    image: docker.redpanda.com/vectorized/console:master-173596f
+    image: docker.redpanda.com/redpandadata/console:v2.8.3
     restart: on-failure
     entrypoint: /bin/sh
     command: -c "echo \"$$CONSOLE_CONFIG_FILE\" > /tmp/config.yml; /app/console"


### PR DESCRIPTION
previously the `docker-compose up` command
returned error 
`console Error pull access denied for docker.redpanda.com/vectorized/console, repository does not exist`

Thank you for the great post on your blog.
https://aran.dev/posts/getting-started-with-golang-and-kafka/